### PR TITLE
[기능] 스텔라 도메인 수정 및 확장

### DIFF
--- a/prisma/migrations/20250915023909_remove_ui_properties_optimize_audio_jsonb/migration.sql
+++ b/prisma/migrations/20250915023909_remove_ui_properties_optimize_audio_jsonb/migration.sql
@@ -1,0 +1,102 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `instrument_type` on the `planets` table. All the data in the column will be lost.
+  - You are about to drop the column `orbit_a` on the `planets` table. All the data in the column will be lost.
+  - You are about to drop the column `orbit_angular_speed` on the `planets` table. All the data in the column will be lost.
+  - You are about to drop the column `orbit_b` on the `planets` table. All the data in the column will be lost.
+  - You are about to drop the column `orbit_inclination_deg` on the `planets` table. All the data in the column will be lost.
+  - You are about to drop the column `orbit_phase0` on the `planets` table. All the data in the column will be lost.
+  - You are about to drop the column `orbit_radius` on the `planets` table. All the data in the column will be lost.
+  - You are about to drop the column `orbit_rotation_deg` on the `planets` table. All the data in the column will be lost.
+  - You are about to drop the column `orbit_type` on the `planets` table. All the data in the column will be lost.
+  - You are about to drop the column `params` on the `planets` table. All the data in the column will be lost.
+  - You are about to drop the column `bpm` on the `stellar_systems` table. All the data in the column will be lost.
+  - You are about to drop the column `x` on the `stellar_systems` table. All the data in the column will be lost.
+  - You are about to drop the column `y` on the `stellar_systems` table. All the data in the column will be lost.
+  - You are about to drop the column `z` on the `stellar_systems` table. All the data in the column will be lost.
+  - You are about to drop the `patterns` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `created_by_id` to the `stellar_systems` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "public"."CreationMethod" AS ENUM ('MANUAL', 'CLONE');
+
+-- DropForeignKey
+ALTER TABLE "public"."patterns" DROP CONSTRAINT "patterns_planet_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."patterns" DROP CONSTRAINT "patterns_source_pattern_id_fkey";
+
+-- AlterTable
+ALTER TABLE "public"."planets" DROP COLUMN "instrument_type",
+DROP COLUMN "orbit_a",
+DROP COLUMN "orbit_angular_speed",
+DROP COLUMN "orbit_b",
+DROP COLUMN "orbit_inclination_deg",
+DROP COLUMN "orbit_phase0",
+DROP COLUMN "orbit_radius",
+DROP COLUMN "orbit_rotation_deg",
+DROP COLUMN "orbit_type",
+DROP COLUMN "params",
+ADD COLUMN     "audio_properties" JSONB DEFAULT '{}',
+ADD COLUMN     "instrument_role" TEXT,
+ADD COLUMN     "is_active" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "planet_type" TEXT NOT NULL DEFAULT 'PLANET';
+
+-- AlterTable
+ALTER TABLE "public"."stellar_systems" DROP COLUMN "bpm",
+DROP COLUMN "x",
+DROP COLUMN "y",
+DROP COLUMN "z",
+ADD COLUMN     "created_by_id" TEXT NOT NULL,
+ADD COLUMN     "created_via" "public"."CreationMethod" NOT NULL DEFAULT 'MANUAL';
+
+-- DropTable
+DROP TABLE "public"."patterns";
+
+-- CreateTable
+CREATE TABLE "public"."options" (
+    "id" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "sort" INTEGER NOT NULL DEFAULT 0,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "options_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "options_code_key" ON "public"."options"("code");
+
+-- CreateIndex
+CREATE INDEX "galaxies_owner_id_idx" ON "public"."galaxies"("owner_id");
+
+-- CreateIndex
+CREATE INDEX "likes_user_id_idx" ON "public"."likes"("user_id");
+
+-- CreateIndex
+CREATE INDEX "likes_system_id_idx" ON "public"."likes"("system_id");
+
+-- CreateIndex
+CREATE INDEX "planets_system_id_idx" ON "public"."planets"("system_id");
+
+-- CreateIndex
+CREATE INDEX "planets_instrument_role_idx" ON "public"."planets"("instrument_role");
+
+-- CreateIndex
+CREATE INDEX "stellar_systems_galaxy_id_idx" ON "public"."stellar_systems"("galaxy_id");
+
+-- CreateIndex
+CREATE INDEX "stellar_systems_owner_id_idx" ON "public"."stellar_systems"("owner_id");
+
+-- CreateIndex
+CREATE INDEX "stellar_systems_created_by_id_idx" ON "public"."stellar_systems"("created_by_id");
+
+-- CreateIndex
+CREATE INDEX "stellar_systems_source_system_id_idx" ON "public"."stellar_systems"("source_system_id");
+
+-- AddForeignKey
+ALTER TABLE "public"."stellar_systems" ADD CONSTRAINT "stellar_systems_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250915024357_planet_audio_properties_to_properties/migration.sql
+++ b/prisma/migrations/20250915024357_planet_audio_properties_to_properties/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `audio_properties` on the `planets` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."planets" DROP COLUMN "audio_properties",
+ADD COLUMN     "properties" JSONB DEFAULT '{}';

--- a/prisma/migrations/20250915030940_add_star_table_separate_from_planet/migration.sql
+++ b/prisma/migrations/20250915030940_add_star_table_separate_from_planet/migration.sql
@@ -1,0 +1,28 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `planet_type` on the `planets` table. All the data in the column will be lost.
+  - Made the column `instrument_role` on table `planets` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."planets" DROP COLUMN "planet_type",
+ALTER COLUMN "instrument_role" SET NOT NULL;
+
+-- CreateTable
+CREATE TABLE "public"."stars" (
+    "id" TEXT NOT NULL,
+    "system_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL DEFAULT 'CENTRAL STAR',
+    "properties" JSONB DEFAULT '{}',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "stars_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "stars_system_id_key" ON "public"."stars"("system_id");
+
+-- AddForeignKey
+ALTER TABLE "public"."stars" ADD CONSTRAINT "stars_system_id_fkey" FOREIGN KEY ("system_id") REFERENCES "public"."stellar_systems"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250915125802_add_object_type/migration.sql
+++ b/prisma/migrations/20250915125802_add_object_type/migration.sql
@@ -1,0 +1,8 @@
+-- CreateEnum
+CREATE TYPE "public"."ObjectType" AS ENUM ('STAR', 'PLANET');
+
+-- AlterTable
+ALTER TABLE "public"."planets" ADD COLUMN     "object_type" "public"."ObjectType" NOT NULL DEFAULT 'PLANET';
+
+-- AlterTable
+ALTER TABLE "public"."stars" ADD COLUMN     "object_type" "public"."ObjectType" NOT NULL DEFAULT 'STAR';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -110,11 +110,15 @@ model StellarSystem {
   source_system  StellarSystem?  @relation(fields: [source_system_id], references: [id], name: "SourceSystem")
   cloned_systems StellarSystem[] @relation("SourceSystem")
 
-  // (F) 이 시스템에 속한 플래닛들 (1:N)
+  // (F) 중앙 항성 (1:1) - 새로 추가
+  // - Star.system_id -> StellarSystem.id
+  star Star?
+
+  // (G) 이 시스템에 속한 플래닛들 (1:N)
   // - Planet.system_id -> StellarSystem.id
   planets Planet[]
 
-  // (G) 좋아요(선택) (1:N)
+  // (H) 좋아요(선택) (1:N)
   // - Like.system_id -> StellarSystem.id
   // - Like 모델은 별도 정의 필요(복합 유니크로 user당 1번 제한)
   likes Like[]
@@ -128,40 +132,49 @@ model StellarSystem {
   @@map("stellar_systems")
 }
 
-model Planet {
-  id        String @id @default(cuid())
-  system_id String // 소속 시스템 (N:1)
-  name      String
-
+// 중앙 항성 모델 (새로 추가)
+model Star {
+  id         String   @id @default(cuid())
+  system_id  String   @unique // 1:1 관계 (한 시스템당 하나의 항성)
+  name       String   @default("CENTRAL STAR")
+  
+  // SONA 항성 전역 제어 속성들을 JSONB로 저장
+  // StarGlobalProperties: spin→BPM, brightness→Volume, color→Key/Scale, size→Complexity
+  properties Json?    @default("{}")
+  
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
+
+  // 관계: 소속 시스템 (1:1)
+  system StellarSystem @relation(fields: [system_id], references: [id], onDelete: Cascade)
+
+  @@map("stars")
+}
+
+model Planet {
+  id              String    @id @default(cuid())
+  system_id       String    // 소속 시스템 (N:1)
+  name            String
+  
+  // 행성 전용 필드 (planet_type 제거, CENTRAL_STAR는 Star 테이블로 분리)
+  instrument_role String    // 'DRUM' | 'BASS' | 'CHORD' | 'MELODY' | 'ARPEGGIO' | 'PAD'
+  is_active       Boolean   @default(true) // 활성화 상태
+  
+  // SONA 행성별 개별 속성들을 JSONB로 저장 (유연성과 확장성)
+  // PlanetProperties: 개별 악기의 음색, 리듬, 공간감 등 제어
+  properties Json?    @default("{}")
+  
+  created_at      DateTime  @default(now())
+  updated_at      DateTime  @updatedAt
 
   // 관계: 소속 시스템 (N:1)
   // - FK: system_id -> stellar_systems.id
   // - 시스템 삭제 시 플래닛도 함께 삭제
   system StellarSystem @relation(fields: [system_id], references: [id], onDelete: Cascade)
 
-  // 관계: 1:1 패턴 (Planet 기준 0..1)
-  // - Pattern.planet_id가 UNIQUE이므로 행성당 패턴은 최대 1개
-  pattern Pattern?
-
   @@index([system_id])
+  @@index([instrument_role]) // 악기 역할별 조회 최적화  
   @@map("planets")
-}
-
-model Pattern {
-  id        String @id @default(cuid())
-  planet_id String @unique // 행성과 1:1 관계 (UNIQUE로 강제)
-
-  created_at DateTime @default(now())
-  updated_at DateTime @updatedAt
-
-  // 관계: 소속 행성 (1:1의 반대편)
-  // - FK: planet_id -> planets.id
-  // - 행성 삭제 시 패턴도 함께 삭제
-  planet Planet @relation(fields: [planet_id], references: [id], onDelete: Cascade)
-
-  @@map("patterns")
 }
 
 model Like {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,12 @@ enum CreationMethod {
   CLONE
 }
 
+// 객체 타입 구분 (항성/행성)
+enum ObjectType {
+  STAR
+  PLANET
+}
+
 model Galaxy {
   id         String   @id @default(cuid())
   name       String
@@ -134,9 +140,10 @@ model StellarSystem {
 
 // 중앙 항성 모델 (새로 추가)
 model Star {
-  id         String   @id @default(cuid())
-  system_id  String   @unique // 1:1 관계 (한 시스템당 하나의 항성)
-  name       String   @default("CENTRAL STAR")
+  id          String     @id @default(cuid())
+  system_id   String     @unique // 1:1 관계 (한 시스템당 하나의 항성)
+  name        String     @default("CENTRAL STAR")
+  object_type ObjectType @default(STAR) // 객체 타입 (항상 STAR)
   
   // SONA 항성 전역 제어 속성들을 JSONB로 저장
   // StarGlobalProperties: spin→BPM, brightness→Volume, color→Key/Scale, size→Complexity
@@ -152,9 +159,10 @@ model Star {
 }
 
 model Planet {
-  id              String    @id @default(cuid())
-  system_id       String    // 소속 시스템 (N:1)
+  id              String     @id @default(cuid())
+  system_id       String     // 소속 시스템 (N:1)
   name            String
+  object_type     ObjectType @default(PLANET) // 객체 타입 (항상 PLANET)
   
   // 행성 전용 필드 (planet_type 제거, CENTRAL_STAR는 Star 테이블로 분리)
   instrument_role String    // 'DRUM' | 'BASS' | 'CHORD' | 'MELODY' | 'ARPEGGIO' | 'PAD'

--- a/src/modules/stellar-systems/dto/star.dto.ts
+++ b/src/modules/stellar-systems/dto/star.dto.ts
@@ -11,6 +11,12 @@ import {
 import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
+// ObjectType enum 정의
+export enum ObjectType {
+  STAR = 'STAR',
+  PLANET = 'PLANET',
+}
+
 // 항성 속성 DTO (JSONB로 저장)
 export class StarPropertiesDto {
   @ApiProperty({
@@ -22,7 +28,8 @@ export class StarPropertiesDto {
   spin: number;
 
   @ApiProperty({
-    description: '항성 밝기 (전체 볼륨 결정)',
+    description:
+      '항성 밝기 (전체 음색 특성 결정 - 어두우면 따뜻하고 부드러운 톤, 밝으면 선명하고 날카로운 톤)',
     minimum: 0,
     maximum: 100,
     example: 75,
@@ -79,7 +86,8 @@ export class CreateStarDto {
   system_id: string;
 
   @ApiProperty({
-    description: '항성의 기본 속성 데이터 (JSONB) - 시스템 생성 시 기본값으로 설정',
+    description:
+      '항성의 기본 속성 데이터 (JSONB) - 시스템 생성 시 기본값으로 설정',
     type: StarPropertiesDto,
   })
   @IsObject()
@@ -108,6 +116,13 @@ export class StarResponseDto {
 
   @ApiProperty({ description: '스텔라 시스템 ID' })
   system_id: string;
+
+  @ApiProperty({
+    description: '객체 타입 (항성은 항상 STAR)',
+    enum: ObjectType,
+    example: ObjectType.STAR,
+  })
+  object_type: ObjectType;
 
   @ApiProperty({
     description: '항성 속성',

--- a/src/modules/stellar-systems/dto/star.dto.ts
+++ b/src/modules/stellar-systems/dto/star.dto.ts
@@ -1,0 +1,123 @@
+// Star(항성) 관련 DTO
+// 전역 오디오 제어를 담당하는 항성의 데이터 전송 객체들
+
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsObject,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+// 항성 속성 DTO (JSONB로 저장)
+export class StarPropertiesDto {
+  @ApiProperty({
+    description: '항성 자전 속도 (전체 BPM 결정)',
+    minimum: 0,
+    maximum: 100,
+    example: 50,
+  })
+  spin: number;
+
+  @ApiProperty({
+    description: '항성 밝기 (전체 볼륨 결정)',
+    minimum: 0,
+    maximum: 100,
+    example: 75,
+  })
+  brightness: number;
+
+  @ApiProperty({
+    description: '항성 색상 (Key/Scale 결정)',
+    minimum: 0,
+    maximum: 360,
+    example: 60,
+  })
+  color: number;
+
+  @ApiProperty({
+    description: '항성 크기 (패턴 복잡도 결정)',
+    minimum: 0,
+    maximum: 100,
+    example: 50,
+  })
+  size: number;
+
+  @ApiPropertyOptional({
+    description: '항성 색온도 (시각적 표현용)',
+    minimum: 0,
+    maximum: 100,
+  })
+  temperature?: number;
+
+  @ApiPropertyOptional({
+    description: '항성 광도 (시각적 표현용)',
+    minimum: 0,
+    maximum: 100,
+  })
+  luminosity?: number;
+
+  @ApiPropertyOptional({
+    description: '항성 반지름 (시각적 표현용)',
+    minimum: 0,
+    maximum: 100,
+  })
+  radius?: number;
+}
+
+// 항성 생성 DTO (시스템 생성 시 내부적으로만 사용)
+// 사용자는 직접 항성을 생성할 수 없고, 스텔라 시스템 생성 시 자동으로 생성됨
+export class CreateStarDto {
+  @ApiProperty({
+    description: '스텔라 시스템 ID (내부적으로만 사용)',
+    example: 'cm1234567890abcdef',
+  })
+  @IsString()
+  @IsNotEmpty()
+  system_id: string;
+
+  @ApiProperty({
+    description: '항성의 기본 속성 데이터 (JSONB) - 시스템 생성 시 기본값으로 설정',
+    type: StarPropertiesDto,
+  })
+  @IsObject()
+  @ValidateNested()
+  @Type(() => StarPropertiesDto)
+  properties: StarPropertiesDto;
+}
+
+// 항성 수정 DTO
+export class UpdateStarDto {
+  @ApiPropertyOptional({
+    description: '수정할 항성 속성 (부분 수정 가능)',
+    type: StarPropertiesDto,
+  })
+  @IsOptional()
+  @IsObject()
+  @ValidateNested()
+  @Type(() => StarPropertiesDto)
+  properties?: Partial<StarPropertiesDto>;
+}
+
+// 항성 응답 DTO
+export class StarResponseDto {
+  @ApiProperty({ description: '항성 ID' })
+  id: string;
+
+  @ApiProperty({ description: '스텔라 시스템 ID' })
+  system_id: string;
+
+  @ApiProperty({
+    description: '항성 속성',
+    type: StarPropertiesDto,
+  })
+  properties: StarPropertiesDto;
+
+  @ApiProperty({ description: '생성 시간' })
+  created_at: Date;
+
+  @ApiProperty({ description: '수정 시간' })
+  updated_at: Date;
+}

--- a/src/modules/stellar-systems/dto/stellar-systems.dto.ts
+++ b/src/modules/stellar-systems/dto/stellar-systems.dto.ts
@@ -16,8 +16,8 @@ import { Type } from 'class-transformer';
 import { StarPropertiesDto } from './star.dto';
 
 // 오디오 관련 타입 정의
-export enum PlanetType {
-  CENTRAL_STAR = 'CENTRAL_STAR',
+export enum ObjectType {
+  STAR = 'STAR',
   PLANET = 'PLANET',
 }
 
@@ -112,6 +112,88 @@ export class CreatePlanetDto {
   @IsOptional()
   @IsObject()
   properties?: any;
+}
+
+// 행성 수정 DTO
+export class UpdatePlanetDto {
+  @ApiPropertyOptional({
+    description: '행성 이름',
+    example: 'Updated Planet Name',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: '악기 역할',
+    enum: InstrumentRole,
+    example: InstrumentRole.MELODY,
+  })
+  @IsOptional()
+  @IsEnum(InstrumentRole)
+  role?: InstrumentRole;
+
+  @ApiPropertyOptional({
+    description: '행성의 속성들 (부분 수정 가능)',
+    example: {
+      planetSize: 0.6,
+      planetColor: 200,
+    },
+  })
+  @IsOptional()
+  @IsObject()
+  properties?: any;
+}
+
+// 행성 응답 DTO
+export class PlanetResponseDto {
+  @ApiProperty({ description: '행성 ID' })
+  id: string;
+
+  @ApiProperty({ description: '스텔라 시스템 ID' })
+  system_id: string;
+
+  @ApiProperty({ description: '행성 이름' })
+  name: string;
+
+  @ApiProperty({
+    description: '객체 타입 (행성은 항상 PLANET)',
+    enum: ObjectType,
+    example: ObjectType.PLANET,
+  })
+  object_type: ObjectType;
+
+  @ApiProperty({
+    description: '악기 역할',
+    enum: InstrumentRole,
+    example: InstrumentRole.DRUM,
+  })
+  role: InstrumentRole;
+
+  @ApiProperty({
+    description: '행성 속성',
+    example: {
+      planetSize: 0.5,
+      planetColor: 180,
+      planetBrightness: 2.65,
+      distanceFromStar: 10.5,
+      orbitSpeed: 0.5,
+      rotationSpeed: 0.5,
+      eccentricity: 0.45,
+      tilt: 90.0,
+    },
+  })
+  properties: any;
+
+  @ApiProperty({ description: '활성화 상태' })
+  is_active: boolean;
+
+  @ApiProperty({ description: '생성 시간' })
+  created_at: Date;
+
+  @ApiProperty({ description: '수정 시간' })
+  updated_at: Date;
 }
 
 // 스텔라 시스템 수정 DTO

--- a/src/modules/stellar-systems/dto/stellar-systems.dto.ts
+++ b/src/modules/stellar-systems/dto/stellar-systems.dto.ts
@@ -7,15 +7,231 @@ import {
   MaxLength,
   ValidateIf,
   ValidateNested,
+  IsEnum,
+  IsObject,
+  IsBoolean,
 } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { Type } from 'class-transformer';
+import { StarPropertiesDto } from './star.dto';
+
+// 오디오 관련 타입 정의
+export enum PlanetType {
+  CENTRAL_STAR = 'CENTRAL_STAR',
+  PLANET = 'PLANET',
+}
+
+export enum InstrumentRole {
+  DRUM = 'DRUM',
+  BASS = 'BASS',
+  CHORD = 'CHORD',
+  MELODY = 'MELODY',
+  ARPEGGIO = 'ARPEGGIO',
+  PAD = 'PAD',
+}
+
+// === 새로운 Star/Planet 분리 구조 DTO ===
+
+// 스텔라 시스템 생성 DTO (항성 자동 생성)
+export class CreateStellarSystemDto {
+  @ApiProperty({
+    description: '스텔라 시스템 이름',
+    example: 'My First System',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+
+  @ApiProperty({
+    description: '소속 갤럭시 ID',
+    example: 'gal_abc123',
+  })
+  @IsString()
+  @IsNotEmpty()
+  galaxy_id: string;
+
+  @ApiPropertyOptional({
+    description: '스텔라 시스템 설명',
+    example: 'A beautiful stellar system with multiple planets',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @ApiPropertyOptional({
+    description: '항성의 초기 속성 (선택적, 미제공 시 기본값 사용)',
+    type: StarPropertiesDto,
+    example: {
+      spin: 50,
+      brightness: 75,
+      color: 60,
+      size: 50,
+    },
+  })
+  @IsOptional()
+  @IsObject()
+  @ValidateNested()
+  @Type(() => StarPropertiesDto)
+  star_properties?: StarPropertiesDto;
+}
+
+// 행성 생성 DTO (시스템에 행성 추가용)
+export class CreatePlanetDto {
+  @ApiProperty({
+    description: '행성 이름',
+    example: 'Rhythm Planet',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  name: string;
+
+  @ApiProperty({
+    description: '악기 역할',
+    enum: InstrumentRole,
+    example: InstrumentRole.DRUM,
+  })
+  @IsEnum(InstrumentRole)
+  role: InstrumentRole;
+
+  @ApiPropertyOptional({
+    description: '행성의 속성들 (JSONB 형태)',
+    example: {
+      planetSize: 0.5,
+      planetColor: 180,
+      planetBrightness: 2.65,
+      distanceFromStar: 10.5,
+      orbitSpeed: 0.5,
+      rotationSpeed: 0.5,
+      eccentricity: 0.45,
+      tilt: 90.0,
+    },
+  })
+  @IsOptional()
+  @IsObject()
+  properties?: any;
+}
+
+// 스텔라 시스템 수정 DTO
+export class UpdateStellarSystemDto {
+  @ApiPropertyOptional({
+    description: '스텔라 시스템 이름',
+    example: 'Updated System Name',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: '스텔라 시스템 설명',
+    example: 'Updated description',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+}
+
+// 스텔라 시스템 클론 DTO
+export class CloneStellarSystemDto {
+  @ApiProperty({
+    description: '클론할 원본 스텔라 시스템 ID',
+    example: 'sys_abc123',
+  })
+  @IsString()
+  @IsNotEmpty()
+  source_system_id: string;
+
+  @ApiProperty({
+    description: '새로운 시스템 이름',
+    example: 'Cloned System',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+
+  @ApiProperty({
+    description: '새로운 시스템이 속할 갤럭시 ID',
+    example: 'gal_xyz789',
+  })
+  @IsString()
+  @IsNotEmpty()
+  galaxy_id: string;
+
+  @ApiPropertyOptional({
+    description: '새로운 시스템 설명',
+    example: 'Cloned from original system',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+}
+
+// === 기존 레거시 DTO (하위 호환성 유지) ===
 
 export class ComposePlanetDto {
   @ApiProperty({ example: 'Planet A' })
   @IsString()
   @MaxLength(50)
   name!: string;
+
+  @ApiPropertyOptional({
+    enum: PlanetType,
+    example: PlanetType.PLANET,
+    description: '행성 타입: CENTRAL_STAR(항성) 또는 PLANET(행성)',
+  })
+  @IsEnum(PlanetType)
+  @IsOptional()
+  planet_type?: PlanetType;
+
+  @ApiPropertyOptional({
+    enum: InstrumentRole,
+    example: InstrumentRole.MELODY,
+    description: '악기 역할: DRUM, BASS, CHORD, MELODY, ARPEGGIO, PAD',
+  })
+  @IsEnum(InstrumentRole)
+  @IsOptional()
+  instrument_role?: InstrumentRole;
+
+  @ApiPropertyOptional({
+    example: true,
+    description: '행성 활성화 상태',
+  })
+  @IsBoolean()
+  @IsOptional()
+  is_active?: boolean;
+
+  // JSONB로 저장될 오디오 및 UI 속성들 (PlanetPhysicalProperties와 동일)
+  // 오디오 제어와 동시에 UI 표현(색상, 크기, 궤도 등)도 이 데이터로 처리
+  @ApiPropertyOptional({
+    description:
+      'SONA 오디오 및 UI 속성들 (JSONB 형태) - 오디오 제어와 UI 표현을 모두 처리',
+    example: {
+      planetSize: 0.5,
+      planetColor: 180,
+      planetBrightness: 2.65,
+      distanceFromStar: 10.5,
+      orbitSpeed: 0.5,
+      rotationSpeed: 0.5,
+      inclination: 0,
+      eccentricity: 0.45,
+      tilt: 90.0,
+      oscillatorType: 0,
+      filterResonance: 1.0,
+      spatialDepth: 50,
+      patternComplexity: 50,
+      rhythmDensity: 50,
+      melodicVariation: 50,
+    },
+  })
+  @IsObject()
+  @IsOptional()
+  properties?: any;
 }
 
 export class ComposeSystemDto {

--- a/src/modules/stellar-systems/stellar-systems.controller.ts
+++ b/src/modules/stellar-systems/stellar-systems.controller.ts
@@ -1,4 +1,14 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Query,
+  Post,
+  Body,
+  Put,
+  Delete,
+  Param,
+  UseGuards,
+} from '@nestjs/common';
 import { StellarSystemService } from './stellar-systems.service';
 import { User } from '../../auth/decorator/user.decorator';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
@@ -8,8 +18,12 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { ComposeRequestDto } from './dto/stellar-systems.dto';
-import { UseGuards, Post, Body } from '@nestjs/common';
+import {
+  ComposeRequestDto,
+  CreateStellarSystemDto,
+  UpdateStellarSystemDto,
+  CloneStellarSystemDto,
+} from './dto/stellar-systems.dto';
 import { ErrorResponseDto } from '../../common/dto/error-response.dto';
 import { PaginationDto } from '../../common/dto/pagination.dto';
 
@@ -17,6 +31,115 @@ import { PaginationDto } from '../../common/dto/pagination.dto';
 @Controller('stellar-systems')
 export class StellarSystemController {
   constructor(private readonly stellarSystemService: StellarSystemService) {}
+
+  /**
+   * 새로운 스텔라 시스템 생성 (항성 자동 생성 포함)
+   * - 인증 필요
+   * - 스텔라 시스템과 항성이 동시에 생성됩니다
+   */
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ 
+    summary: '스텔라 시스템 생성',
+    description: '새로운 스텔라 시스템을 생성합니다. 항성은 자동으로 생성되며 삭제할 수 없습니다.'
+  })
+  @ApiResponse({ status: 201, description: '스텔라 시스템 생성 성공' })
+  @ApiResponse({
+    status: 400,
+    description: '잘못된 요청',
+    type: ErrorResponseDto,
+  })
+  async createStellarSystem(
+    @User('userId') userId: string,
+    @Body() createDto: CreateStellarSystemDto,
+  ) {
+    return this.stellarSystemService.createStellarSystem(userId, createDto);
+  }
+
+  /**
+   * 스텔라 시스템 클론 (원본을 복제하여 새 시스템 생성)
+   * - 인증 필요
+   * - 원본 시스템의 항성과 행성들을 모두 복제합니다
+   * - created_via: 'CLONE'으로 설정됩니다
+   */
+  @Post('clone')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: '스텔라 시스템 클론',
+    description:
+      '기존 스텔라 시스템을 복제하여 새로운 시스템을 생성합니다. 항성과 행성들이 모두 복제됩니다.',
+  })
+  @ApiResponse({ status: 201, description: '스텔라 시스템 클론 성공' })
+  @ApiResponse({
+    status: 400,
+    description: '잘못된 요청',
+    type: ErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: '원본 시스템을 찾을 수 없음',
+    type: ErrorResponseDto,
+  })
+  async cloneStellarSystem(
+    @User('userId') userId: string,
+    @Body() cloneDto: CloneStellarSystemDto,
+  ) {
+    return this.stellarSystemService.cloneStellarSystem(userId, cloneDto);
+  }
+
+  /**
+   * 스텔라 시스템 조회 (항성 및 행성 포함)
+   */
+  @Get(':id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '스텔라 시스템 조회' })
+  @ApiResponse({ status: 200, description: '조회 성공' })
+  @ApiResponse({ status: 404, description: '스텔라 시스템을 찾을 수 없음' })
+  async getStellarSystem(
+    @Param('id') id: string,
+    @User('userId') userId: string,
+  ) {
+    return this.stellarSystemService.getStellarSystem(id, userId);
+  }
+
+  /**
+   * 스텔라 시스템 수정
+   */
+  @Put(':id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '스텔라 시스템 수정' })
+  @ApiResponse({ status: 200, description: '수정 성공' })
+  @ApiResponse({ status: 404, description: '스텔라 시스템을 찾을 수 없음' })
+  async updateStellarSystem(
+    @Param('id') id: string,
+    @User('userId') userId: string,
+    @Body() updateDto: UpdateStellarSystemDto,
+  ) {
+    return this.stellarSystemService.updateStellarSystem(id, userId, updateDto);
+  }
+
+  /**
+   * 스텔라 시스템 삭제 (항성도 함께 삭제됨)
+   */
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ 
+    summary: '스텔라 시스템 삭제',
+    description: '스텔라 시스템을 삭제합니다. 포함된 항성과 행성들도 함께 삭제됩니다.'
+  })
+  @ApiResponse({ status: 200, description: '삭제 성공' })
+  @ApiResponse({ status: 404, description: '스텔라 시스템을 찾을 수 없음' })
+  async deleteStellarSystem(
+    @Param('id') id: string,
+    @User('userId') userId: string,
+  ) {
+    return this.stellarSystemService.deleteStellarSystem(id, userId);
+  }
 
   /**
    * 은하계, 항성계, 행성을 한 번에 생성 또는 연결

--- a/src/modules/stellar-systems/stellar-systems.service.ts
+++ b/src/modules/stellar-systems/stellar-systems.service.ts
@@ -84,6 +84,7 @@ export class StellarSystemService {
         star: {
           id: star.id,
           system_id: star.system_id,
+          name: star.name,
           object_type: 'STAR' as const,
           properties: star.properties,
           created_at: star.created_at,

--- a/src/modules/stellar-systems/stellar-systems.service.ts
+++ b/src/modules/stellar-systems/stellar-systems.service.ts
@@ -347,7 +347,7 @@ export class StellarSystemService {
                 ? {
                     create: systemDto.planets.map(p => ({
                       name: p.name,
-                      planet_type: p.planet_type || 'PLANET',
+                      object_type: 'PLANET',
                       instrument_role: p.instrument_role || null,
                       is_active: p.is_active ?? true,
                       properties: p.properties || {},


### PR DESCRIPTION
## 데이터베이스 스키마 리팩터링 및 개선
•	항성과 행성 테이블 분리:
stars 테이블을 새로 도입하고, 이를 stellar_systems와 1:1 관계로 설정했습니다.
planets 테이블은 중심 항성 로직을 제거하고 행성 속성에 집중하도록 업데이트했습니다.
두 테이블 모두 명시적 타입 구분을 위해 object_type enum을 추가했습니다.

•	레거시 및 중복 컬럼 제거:
planets와 stellar_systems의 불필요한 컬럼을 삭제하고, patterns 테이블을 드롭했습니다.
다양한 UI/오디오 관련 컬럼을 제거하고, stars 및 planets 모두에 유연한 properties JSONB 컬럼을 도입했습니다.

•	인덱스 및 외래키 추가:
새로운 스키마에 맞게 쿼리 최적화와 참조 무결성 보장을 위한 인덱스와 FK를 추가했습니다.

## API 및 DTO 업데이트
•	새로운 DTO 추가 및 리팩터링:
Star에 대한 생성/업데이트/응답 DTO를 추가하고, Planet DTO는 새로운 스키마에 맞게 리팩터링했습니다.
타입 안정성과 명확성을 위해 ObjectType 및 InstrumentRole enum을 도입했습니다.

•	항성계 생성 DTO 확장:
항성을 자동 생성하고 초기 속성을 선택적으로 설정할 수 있도록 주요 Stellar System 생성 DTO를 업데이트했습니다.

## 컨트롤러 및 서비스 확장
•	StellarSystemController 개선:
항성계를 생성, 복제, 업데이트, 조회, 삭제할 수 있는 엔드포인트를 확장했습니다.
새로운 스키마에 맞춰 연관된 항성과 행성도 함께 처리되도록 했습니다.
모든 관련 엔드포인트는 인증을 요구하며, 상세한 Swagger 문서를 제공합니다.