### PR TITLE
[수정] likes router 구조 변경 및 유저프로필 변경

### DIFF
--- a/src/common/utils/kst-range.util.ts
+++ b/src/common/utils/kst-range.util.ts
@@ -1,7 +1,11 @@
-export type KstRange = 'week' | 'month' | 'year';
+export type KstRange = 'week' | 'month' | 'year' | 'total';
 const KST = 9 * 60 * 60 * 1000;
 
-export function getKstRangeUTC(range: KstRange): { gte: Date; lte: Date } {
+export function getKstRangeUTC(
+  range: KstRange
+): { gte: Date; lte: Date } | null {
+  if (range === 'total') return null; // ← 추가: total은 기간 필터 없음
+
   const nowUTC = new Date();
   const nowKST = new Date(nowUTC.getTime() + KST);
   const startKST = new Date(nowKST);

--- a/src/modules/likes/dto/likes.dto.ts
+++ b/src/modules/likes/dto/likes.dto.ts
@@ -23,16 +23,17 @@ export enum RangkType {
   MONTHL = 'month',
   YEAR = 'year',
   RANDOM = 'random',
+  TOTAL = 'total',
 }
 
 export class LikeRankingDto extends PaginationDto {
   @ApiProperty({
-    description: '랭킹 타입 (week, month, year, random)',
+    description: '랭킹 타입 (week, month, year, random, total)',
     example: 'week',
     required: false,
     enum: RangkType,
     default: RangkType.WEEK,
   })
   @IsString()
-  rangk_type?: RangkType = RangkType.WEEK;
+  rank_type?: RangkType = RangkType.WEEK;
 }

--- a/src/modules/likes/likes.controller.ts
+++ b/src/modules/likes/likes.controller.ts
@@ -270,12 +270,12 @@ export class LikesController {
 
   @Get('rankings')
   @ApiOperation({
-    summary: '좋아요 랭킹 조회 (주/월/년/랜덤)',
+    summary: '좋아요 랭킹 조회 (전체/주/월/년/랜덤)',
     description:
       'KST 달력 기준으로 집계. rank_type이 random이면 무작위 시스템을 반환.',
   })
   @ApiQuery({
-    name: 'rangk_type',
+    name: 'rank_type',
     required: false,
     enum: RangkType,
     example: RangkType.WEEK,
@@ -358,87 +358,18 @@ export class LikesController {
       },
     },
   })
+  @ApiResponse({
+    status: 500,
+    description: '잘 못된 요청',
+    type: ErrorResponseDto,
+  })
   @UseGuards(OptionalJwtAuthGuard)
   async getLikeRankings(
     @Req() req: any,
-    @Query() dto: PaginationDto & { rangk_type?: RangkType }
+    @Query() dto: PaginationDto & { rank_type?: RangkType }
   ) {
     const viewerId: string | undefined = req.user?.id; // 로그인 안 했으면 undefined
     return this.likesService.getLikeRankings(dto, viewerId);
-  }
-
-  /** 전체(올타임) 좋아요 Top 랭킹 — 공개 */
-  @Get('rankings-top')
-  @ApiOperation({ summary: '전체(올타임) 좋아요 Top 랭킹' })
-  @ApiQuery({ name: 'page', required: false, example: 1 })
-  @ApiQuery({ name: 'limit', required: false, example: 20 })
-  @ApiOkResponse({
-    description: '조회 성공',
-    content: {
-      'application/json': {
-        schema: {
-          type: 'object',
-          properties: {
-            data: {
-              type: 'array',
-              items: {
-                type: 'object',
-                properties: {
-                  id: { type: 'string', example: 'sys_TOP1' },
-                  title: { type: 'string', example: '오리온-프라임' },
-                  galaxy_id: { type: 'string', example: 'gal_TOP' },
-                  creator_id: { type: 'string', example: 'usr_AAA' },
-                  created_at: {
-                    type: 'string',
-                    format: 'date-time',
-                    example: '2025-01-01T00:00:00.000Z',
-                  },
-                  updated_at: {
-                    type: 'string',
-                    format: 'date-time',
-                    example: '2025-09-14T00:00:00.000Z',
-                  },
-                  planet_count: { type: 'integer', example: 12 },
-                  like_count: { type: 'integer', example: 1234 },
-                  rank: { type: 'integer', example: 1 },
-                  is_liked: { type: 'boolean', example: false },
-                },
-              },
-            },
-            meta: {
-              type: 'object',
-              properties: {
-                page: { type: 'integer', example: 1 },
-                limit: { type: 'integer', example: 20 },
-                total: { type: 'integer', example: 1000 },
-              },
-            },
-          },
-        },
-        example: {
-          data: [
-            {
-              id: 'sys_TOP1',
-              title: '오리온-프라임',
-              galaxy_id: 'gal_TOP',
-              creator_id: 'usr_AAA',
-              created_at: '2025-01-01T00:00:00.000Z',
-              updated_at: '2025-09-14T00:00:00.000Z',
-              planet_count: 12,
-              like_count: 1234,
-              rank: 1,
-              is_liked: false,
-            },
-          ],
-          meta: { page: 1, limit: 20, total: 1000 },
-        },
-      },
-    },
-  })
-  @UseGuards(OptionalJwtAuthGuard)
-  async getTopLiked(@Req() req: any, @Query() dto: PaginationDto) {
-    const viewerId: string | undefined = req.user?.id;
-    return this.likesService.getTopLikedSystems(dto, viewerId);
   }
 
   /**

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -73,6 +73,37 @@ export class PrismaService implements OnModuleInit, OnModuleDestroy {
     await this.client.$disconnect();
     console.log('🔌 Prisma 데이터베이스 연결 해제');
   }
+  // --- $queryRaw (safe) ---
+  $queryRaw<T = unknown>(query: Prisma.Sql): Promise<T>;
+  $queryRaw<T = unknown>(
+    query: TemplateStringsArray,
+    ...values: any[]
+  ): Promise<T>;
+  $queryRaw<T = unknown>(
+    query: Prisma.Sql | TemplateStringsArray,
+    ...values: any[]
+  ): Promise<T> {
+    // PrismaClient의 원본 메서드로 위임
+    return (this.client.$queryRaw as any)(query as any, ...values);
+  }
+
+  // --- $executeRaw (safe) ---
+  $executeRaw(query: Prisma.Sql): Promise<number>;
+  $executeRaw(query: TemplateStringsArray, ...values: any[]): Promise<number>;
+  $executeRaw(
+    query: Prisma.Sql | TemplateStringsArray,
+    ...values: any[]
+  ): Promise<number> {
+    return (this.client.$executeRaw as any)(query as any, ...values);
+  }
+
+  // --- ⚠️ Unsafe: 문자열 직접 결합 금지 ---
+  $queryRawUnsafe<T = unknown>(query: string, ...values: any[]): Promise<T> {
+    return this.client.$queryRawUnsafe<T>(query, ...values);
+  }
+  $executeRawUnsafe(query: string, ...values: any[]): Promise<number> {
+    return this.client.$executeRawUnsafe(query, ...values);
+  }
 
   /**
    * 애플리케이션 종료 시 깔끔한 종료를 위한 후크 설정


### PR DESCRIPTION
- likes → rangkings-top 로직 제거
- likes → total type 추가
- likes → rangk_typ에서 rank_type으로 변경
- likes → likes 기준이 아닌 stellar-system으로 변경
- uitl → KST 기준으로 주/월/년 구간의 시작 시점을 계산해 UTC로 변환해 주는 유틸 강화
- users → 로컬 이미지 테스트 완료
- users → 이미지 업로드  swagger description 자세하게 수정
- prisma → **composition(래핑)** 구조를 유지하면서 `$queryRaw` 관련 메서드만 **패스스루로 추가**