### PR TITLE
[수정] Auth/Follows/Likes 로직 개선 및 Swagger 문서 보강

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -14,6 +14,7 @@ import {
   ApiOperation,
   ApiResponse,
   ApiBearerAuth,
+  ApiCreatedResponse,
 } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { LoginDto, CreateUserDto, LoginResponseDto } from './dto/auth.dto';
@@ -35,9 +36,67 @@ export class AuthController {
   @Post('signup')
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: '사용자 회원가입' })
-  @ApiResponse({
-    status: 201,
+  @ApiCreatedResponse({
     description: '회원가입 성공',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          properties: {
+            message: {
+              type: 'string',
+              example: '회원가입이 완료되었습니다.',
+              description: '결과 메시지',
+            },
+            user: {
+              type: 'object',
+              description: '생성된 사용자 정보 (비밀번호 제외)',
+              properties: {
+                id: {
+                  type: 'string',
+                  example: 'usr_7h3x2k9q',
+                  description: '사용자 고유 ID',
+                },
+                email: {
+                  type: 'string',
+                  example: 'user@example.com',
+                  description: '사용자 이메일',
+                },
+                username: {
+                  type: 'string',
+                  example: 'username123',
+                  description: '사용자명',
+                },
+                created_at: {
+                  type: 'string',
+                  format: 'date-time',
+                  example: '2025-09-18T10:00:00.000Z',
+                  description: '계정 생성 시각',
+                },
+                updated_at: {
+                  type: 'string',
+                  format: 'date-time',
+                  example: '2025-09-18T10:00:00.000Z',
+                  description: '마지막 수정 시각',
+                },
+              },
+              required: ['id', 'email', 'username', 'created_at', 'updated_at'],
+            },
+          },
+          required: ['message', 'user'],
+        },
+        example: {
+          message: '회원가입이 완료되었습니다.',
+          user: {
+            id: 'usr_7h3x2k9q',
+            email: 'user@example.com',
+            username: 'username123',
+            created_at: '2025-09-18T10:00:00.000Z',
+            updated_at: '2025-09-18T10:00:00.000Z',
+          },
+        },
+      },
+    },
   })
   @ApiResponse({
     status: 400,
@@ -64,11 +123,28 @@ export class AuthController {
   @ApiResponse({
     status: 200,
     description: '로그인 성공',
-    type: LoginResponseDto,
+    schema: {
+      example: {
+        access_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+        user: {
+          id: 'usr_12345',
+          email: 'test@example.com',
+          username: 'testuser',
+          about: '안녕하세요, 저는 사용자입니다.',
+          created_at: '2025-09-18T10:00:00.000Z',
+          updated_at: '2025-09-18T10:30:00.000Z',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: '잘못된 요청 (형식 오류)',
+    type: ErrorResponseDto,
   })
   @ApiResponse({
     status: 401,
-    description: '로그인 실패',
+    description: '로그인 실패 (사용자 없음/비밀번호 불일치)',
     type: ErrorResponseDto,
   })
   async login(@Body() body: LoginDto): Promise<LoginResponseDto> {

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -4,8 +4,9 @@ import {
   IsString,
   MinLength,
   MaxLength,
+  ValidateIf,
 } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 /**
  * 회원가입 요청 DTO
@@ -45,17 +46,14 @@ export class CreateUserDto {
   password: string;
 }
 
-/**
- * 로그인 요청 DTO
- **/
 export class LoginDto {
   @ApiProperty({
-    description: '사용자 이메일',
-    example: 'user@example.com',
+    description: '사용자 이메일 또는 사용자명',
+    example: 'user@example.com 또는 testuser',
   })
-  @IsEmail({}, { message: '올바른 이메일 형식이 아닙니다.' })
-  @IsNotEmpty({ message: '이메일은 필수입니다.' })
-  email: string;
+  @IsString({ message: '이메일 또는 사용자명은 문자열이어야 합니다.' })
+  @IsNotEmpty({ message: '이메일 또는 사용자명을 입력해야 합니다.' })
+  identifier: string;
 
   @ApiProperty({
     description: '사용자 비밀번호',
@@ -95,17 +93,3 @@ export class LoginResponseDto {
     updated_at: Date;
   };
 }
-
-/**
- * 로그아웃 요청 DTO (임시)
- */
-export class LogoutDto {
-  @ApiProperty({
-    description: '사용자 ID',
-    example: '1a2b3c4d5e6f',
-  })
-  @IsNotEmpty({ message: '사용자 ID는 필수입니다.' })
-  userId: string; 
-}
-
-

--- a/src/modules/follows/dto/follows.dto.ts
+++ b/src/modules/follows/dto/follows.dto.ts
@@ -1,9 +1,15 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString, NotEquals } from 'class-validator';
-import { PaginationDto } from '../../../common/dto/pagination.dto';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsString,
+  NotEquals,
+  IsInt,
+  Min,
+  Max,
+} from 'class-validator';
 
 /**
- * 팔로우 생성 DTO
+ * 팔로우 생성 DTO (그대로 사용 가능)
  */
 export class CreateFollowDto {
   @ApiProperty({ description: '팔로우 대상 사용자 ID' })
@@ -14,7 +20,7 @@ export class CreateFollowDto {
 }
 
 /**
- * 팔로우 취소 DTO
+ * 팔로우 취소 DTO (그대로 사용 가능)
  */
 export class DeleteFollowDto {
   @ApiProperty({ description: '팔로우 대상 사용자 ID' })
@@ -25,55 +31,90 @@ export class DeleteFollowDto {
 }
 
 /**
- * 팔로우 사용자 정보 DTO
+ * 페이지네이션 쿼리 (PaginationDto 대체/확장: page, limit만 노출)
+ * 기존 PaginationDto 쓰고 있다면 이 클래스는 생략해도 됩니다.
  */
-export class FollowUserDto {
-  @ApiProperty() id!: string;
-  @ApiProperty({ required: false }) username?: string | null;
-  @ApiProperty({ required: false }) email?: string | null;
-  @ApiProperty({ required: false, type: String, format: 'date-time' })
-  created_at?: Date | null;
+export class SimplePaginationDto {
+  @ApiProperty({ example: 1, description: '현재 페이지(1-base)' })
+  @IsInt()
+  @Min(1)
+  page!: number;
+
+  @ApiProperty({ example: 20, description: '페이지당 개수(1~100)' })
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit!: number;
 }
 
 /**
- * 팔로우 목록 조회 DTO
+ * 목록 아이템 DTO: viewer 기준 플래그 포함
  */
-export class GetFollowsDto extends PaginationDto {
-  @ApiProperty({ description: '사용자 ID' })
-  @IsString()
-  @IsNotEmpty()
-  userId!: string;
+export class FollowUserSummaryDto {
+  @ApiProperty({ description: '사용자 ID', example: 'usr_abc123' })
+  id!: string;
+
+  @ApiProperty({ description: '사용자명', example: 'charlie' })
+  username!: string;
+
+  @ApiPropertyOptional({
+    description:
+      '뷰어(로그인 사용자)가 이 사용자를 팔로우 중인지 여부.\n' +
+      '- true: 뷰어 → 사용자 방향 팔로우 중\n' +
+      '- false: 팔로우하지 않음\n' +
+      '- 비로그인 시 기본적으로 false(또는 정책에 따라 undefined로 숨길 수 있음)',
+    example: true,
+  })
+  viewer_is_following?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      '이 사용자가 뷰어(로그인 사용자)를 팔로우 중인지 여부.\n' +
+      '- true: 사용자 → 뷰어 방향 팔로우 중(“나를 팔로우함” 배지 등에 활용)\n' +
+      '- false: 팔로우하지 않음\n' +
+      '- 비로그인 시 기본적으로 false(또는 정책에 따라 undefined)',
+    example: false,
+  })
+  viewer_is_followed_by?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      '맞팔 여부. viewer_is_following && viewer_is_followed_by가 둘 다 true일 때 true.\n' +
+      '- true: 서로 팔로우 중(맞팔)\n' +
+      '- false: 한쪽만 팔로우하거나 둘 다 아님\n' +
+      '- 비로그인 시 기본적으로 false(또는 정책에 따라 undefined)',
+    example: false,
+  })
+  isMutual?: boolean;
 }
 
 /**
- *  팔로워 목록 조회 DTO
- */
-export class GetFollowersDto extends PaginationDto {
-  @ApiProperty({ description: '사용자 ID' })
-  @IsString()
-  @IsNotEmpty()
-  userId!: string;
-}
-
-/**
- * 페이지네이션 응답 메타 (클래스로 변경하여 Swagger 노출)
+ * 페이지네이션 응답 메타
  */
 export class PaginationMetaDto {
-  @ApiProperty() page!: number;
-  @ApiProperty() limit!: number;
-  @ApiProperty() total!: number;
-  @ApiProperty() totalPages!: number;
-  @ApiProperty() hasNext!: boolean;
-  @ApiProperty() hasPrev!: boolean;
+  @ApiProperty({ example: 1 }) page!: number;
+  @ApiProperty({ example: 20 }) limit!: number;
+  @ApiProperty({ example: 137 }) total!: number;
+  @ApiProperty({ example: 7 }) totalPages!: number;
+  @ApiProperty({ example: true }) hasNext!: boolean;
+  @ApiProperty({ example: false }) hasPrev!: boolean;
 }
 
 /**
- * 페이지네이션 응답
- * 아래는 예시로 팔로우 사용자 전용
+ * 팔로워/팔로잉 목록 공통 응답 DTO
+ * (원하면 하나만 써도 되고, 가독성을 위해 두 개를 구분해도 됩니다)
  */
-export class PaginatedFollowUsersDto {
-  @ApiProperty({ type: [FollowUserDto] })
-  data!: FollowUserDto[];
+export class FollowersListResponseDto {
+  @ApiProperty({ type: [FollowUserSummaryDto] })
+  items!: FollowUserSummaryDto[];
+
+  @ApiProperty({ type: PaginationMetaDto })
+  meta!: PaginationMetaDto;
+}
+
+export class FollowingsListResponseDto {
+  @ApiProperty({ type: [FollowUserSummaryDto] })
+  items!: FollowUserSummaryDto[];
 
   @ApiProperty({ type: PaginationMetaDto })
   meta!: PaginationMetaDto;

--- a/src/modules/likes/likes.controller.ts
+++ b/src/modules/likes/likes.controller.ts
@@ -175,7 +175,9 @@ export class LikesController {
                     format: 'date-time',
                     example: '2025-09-16T12:03:22.000Z',
                   },
+                  like_count: { type: 'number', example: 1 },
                   is_liked: { type: 'boolean', example: true },
+                  creator_name: { type: 'string', example: 'creator_name' },
                 },
               },
             },
@@ -203,7 +205,9 @@ export class LikesController {
                   updated_at: '2025-09-12T15:45:00.000Z',
                   planet_count: 5,
                   liked_at: '2025-09-16T12:03:22.000Z',
+                  like_count: 1,
                   is_liked: true,
+                  creator_name: 'creator_name',
                 },
               ],
               meta: { page: 1, limit: 20, total: 132 },
@@ -313,6 +317,7 @@ export class LikesController {
                   like_count: { type: 'integer', example: 42 },
                   rank: { type: 'integer', example: 1 },
                   is_liked: { type: 'boolean', example: false },
+                  creator_name: { type: 'string', example: 'creator_name' },
                 },
               },
             },
@@ -339,6 +344,7 @@ export class LikesController {
               like_count: 42,
               rank: 1,
               is_liked: false,
+              creator_name: 'creator_name',
             },
             {
               id: 'sys_654',
@@ -351,6 +357,7 @@ export class LikesController {
               like_count: 37,
               rank: 2,
               is_liked: false,
+              creator_name: 'creator_name',
             },
           ],
           meta: { page: 1, limit: 20, total: 250 },
@@ -370,90 +377,5 @@ export class LikesController {
   ) {
     const viewerId: string | undefined = req.user?.id; // 로그인 안 했으면 undefined
     return this.likesService.getLikeRankings(dto, viewerId);
-  }
-
-  /**
-   * 특정 사용자가 좋아요 누른 항성계 목록 조회 — 공개
-   * (정적 라우트들 아래에 배치해서 충돌 방지)
-   */
-  @Get(':userId')
-  @ApiOperation({ summary: '특정 사용자가 좋아요 누른 항성계 목록 조회' })
-  @ApiOkResponse({
-    description: '조회 성공',
-    content: {
-      'application/json': {
-        schema: {
-          type: 'object',
-          properties: {
-            data: {
-              type: 'array',
-              items: {
-                type: 'object',
-                properties: {
-                  id: { type: 'string', example: 'sys_777' },
-                  title: { type: 'string', example: '카시오페이아-β' },
-                  galaxy_id: { type: 'string', example: 'gal_900' },
-                  creator_id: { type: 'string', example: 'usr_XYZ' },
-                  created_at: {
-                    type: 'string',
-                    format: 'date-time',
-                    example: '2025-05-01T00:00:00.000Z',
-                  },
-                  updated_at: {
-                    type: 'string',
-                    format: 'date-time',
-                    example: '2025-08-31T00:00:00.000Z',
-                  },
-                  planet_count: { type: 'integer', example: 3 },
-                  liked_at: {
-                    type: 'string',
-                    format: 'date-time',
-                    example: '2025-09-15T04:12:34.000Z',
-                  },
-                  is_liked: { type: 'boolean', example: false },
-                },
-              },
-            },
-            meta: {
-              type: 'object',
-              properties: {
-                page: { type: 'integer', example: 1 },
-                limit: { type: 'integer', example: 20 },
-                total: { type: 'integer', example: 12 },
-              },
-            },
-          },
-        },
-        example: {
-          data: [
-            {
-              id: 'sys_777',
-              title: '카시오페이아-β',
-              galaxy_id: 'gal_900',
-              creator_id: 'usr_XYZ',
-              created_at: '2025-05-01T00:00:00.000Z',
-              updated_at: '2025-08-31T00:00:00.000Z',
-              planet_count: 3,
-              liked_at: '2025-09-15T04:12:34.000Z',
-              is_liked: false,
-            },
-          ],
-          meta: { page: 1, limit: 20, total: 12 },
-        },
-      },
-    },
-  })
-  @ApiResponse({
-    status: 404,
-    description: '사용자 없음',
-    type: ErrorResponseDto,
-  })
-  @ApiQuery({ name: 'page', required: false, example: 1 })
-  @ApiQuery({ name: 'limit', required: false, example: 20 })
-  async getUserLikedSystems(
-    @Param('userId') userId: string,
-    @Query() pagination: PaginationDto
-  ) {
-    return this.likesService.getMyLikes(userId, pagination);
   }
 }


### PR DESCRIPTION
 Auth 
- 로그인 시 **username 또는 email** 중 하나로 로그인 가능하도록 구현
- 회원가입 API 응답 값 **Swagger 문서화 추가**

Follows

- 사용하지 않는 라우터 제거
- **팔로워/팔로잉 조회 로직 개선**
    - 조회 기준을 항상 **프로필 주인(targetId)** 으로 고정
    - 로그인 사용자(viewer) 기준 관계 플래그 추가:
        - `viewer_is_following`: viewer → user 팔로우 여부
        - `viewer_is_followed_by`: user → viewer 팔로우 여부
        - `isMutual`: 맞팔 여부 (위 두 값 모두 true일 때)

 Likes
- 누락된 필드 값(`like_count`, `creator_name` 등) 추가